### PR TITLE
feat: Add PWA install button

### DIFF
--- a/index.html
+++ b/index.html
@@ -229,6 +229,9 @@
                         <i data-lucide="sun" id="theme-icon-light" class="w-5 h-5"></i>
                         <i data-lucide="moon" id="theme-icon-dark" class="w-5 h-5 hidden"></i>
                     </button>
+                    <button id="install-pwa-btn" class="hidden p-2 rounded-lg hover:bg-white/10 transition-colors" title="Instalar App">
+                        <i data-lucide="download" class="w-5 h-5"></i>
+                    </button>
                 </div>
             </div>
         </div>
@@ -314,6 +317,45 @@
             let currentCalendarDate = new Date();
             let activeReminders = new Map();
             let notificationPermission = false;
+            let deferredPrompt;
+            const installButton = document.getElementById('install-pwa-btn');
+
+            window.addEventListener('beforeinstallprompt', (e) => {
+                // Prevent the mini-infobar from appearing on mobile
+                e.preventDefault();
+                // Stash the event so it can be triggered later.
+                deferredPrompt = e;
+                // Update UI to notify the user they can install the PWA
+                if (installButton) {
+                    installButton.classList.remove('hidden');
+                }
+            });
+
+            if (installButton) {
+                installButton.addEventListener('click', async () => {
+                    // Hide the app provided install promotion
+                    installButton.classList.add('hidden');
+                    // Show the install prompt
+                    deferredPrompt.prompt();
+                    // Wait for the user to respond to the prompt
+                    const { outcome } = await deferredPrompt.userChoice;
+                    console.log(`User response to the install prompt: ${outcome}`);
+                    // We've used the prompt, and can't use it again, throw it away
+                    deferredPrompt = null;
+                });
+            }
+
+            window.addEventListener('appinstalled', () => {
+                // Hide the app-provided install promotion
+                if (installButton) {
+                    installButton.classList.add('hidden');
+                }
+                // Clear the deferredPrompt so it can be garbage collected
+                deferredPrompt = null;
+                // Optionally, send analytics event to indicate successful install
+                console.log('PWA was installed');
+                showToast('Aplicativo instalado com sucesso!', 'success');
+            });
 
             const saveData = () => localStorage.setItem('cuidashiftDB', JSON.stringify(db));
             const loadData = () => {

--- a/sw.js
+++ b/sw.js
@@ -4,7 +4,9 @@ const urlsToCache = [
   '/index.html',
   '/styles.css',
   '/app.js',
-  '/manifest.json'
+  '/manifest.json',
+  '/images/icon-192.png',
+  '/images/icon-512.png'
 ];
 
 self.addEventListener('install', event => {


### PR DESCRIPTION
Adds a button to the header to allow users to install the application as a PWA.

Includes JavaScript to handle the `beforeinstallprompt` event and show the install prompt.

Updates the service worker to cache PWA icons.

Creates the `images` directory to house the icons (though the icons themselves are not included).