### PR TITLE
Fix PWA installation by adding missing icons and updating references.

### DIFF
--- a/images/icon-192.svg
+++ b/images/icon-192.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="192" height="192" viewBox="0 0 192 192">
+  <rect width="100%" height="100%" fill="#3B82F6"/>
+  <text x="50%" y="50%" font-size="48" fill="white" text-anchor="middle" dy=".3em">CS</text>
+</svg>

--- a/images/icon-512.svg
+++ b/images/icon-512.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="512" height="512" viewBox="0 0 512 512">
+  <rect width="100%" height="100%" fill="#3B82F6"/>
+  <text x="50%" y="50%" font-size="128" fill="white" text-anchor="middle" dy=".3em">CS</text>
+</svg>

--- a/index.html
+++ b/index.html
@@ -15,7 +15,7 @@
     <meta name="theme-color" content="#3B82F6">
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
-    <link rel="apple-touch-icon" href="images/icon-192.png">
+    <link rel="apple-touch-icon" href="images/icon-192.svg">
 
     <script>
         tailwind.config = {

--- a/manifest.json
+++ b/manifest.json
@@ -8,13 +8,13 @@
   "description": "Gerenciador de Plantões com IA",
   "icons": [
     {
-      "src": "images/icon-192.png",
-      "type": "image/png",
+      "src": "images/icon-192.svg",
+      "type": "image/svg+xml",
       "sizes": "192x192"
     },
     {
-      "src": "images/icon-512.png",
-      "type": "image/png",
+      "src": "images/icon-512.svg",
+      "type": "image/svg+xml",
       "sizes": "512x512"
     }
   ]

--- a/sw.js
+++ b/sw.js
@@ -5,8 +5,8 @@ const urlsToCache = [
   '/styles.css',
   '/app.js',
   '/manifest.json',
-  '/images/icon-192.png',
-  '/images/icon-512.png'
+  '/images/icon-192.svg',
+  '/images/icon-512.svg'
 ];
 
 self.addEventListener('install', event => {


### PR DESCRIPTION
The application was not installable because the icon files referenced in the manifest.json, sw.js, and index.html were missing. This caused the browser's PWA criteria not to be met and the service worker installation to fail.

This commit resolves the issue by:
1. Creating an `images` directory.
2. Adding placeholder SVG icons (192x192 and 512x512) to the new directory.
3. Updating `manifest.json` to point to the new SVG icons with the correct MIME type.
4. Updating `sw.js` to cache the new SVG icon paths.
5. Updating `index.html` to correct the `apple-touch-icon` link.

These changes should make the application installable as a PWA.